### PR TITLE
Fixed the typescript error: Argument of type 'Object' is not assignable to parameter of type 'string'

### DIFF
--- a/sdk/core/src/moeParser/MoEngagePayloadParser.ts
+++ b/sdk/core/src/moeParser/MoEngagePayloadParser.ts
@@ -37,8 +37,8 @@ export function getMoEAccountMeta(payload: { [k: string]: any }): MoEAccountMeta
  * @returns instance of {@link UserDeletionData}
  * @since 8.6.0
  */
-export function getUserDeletionData(payload: Object): UserDeletionData {
-    const payloadJsonObject = JSON.parse(payload);
+export function getUserDeletionData(payload: Object | string): UserDeletionData {
+    const payloadJsonObject = JSON.parse(payload as string);
     return new UserDeletionData(
         getMoEAccountMeta(payloadJsonObject[ACCOUNT_META]),
         payloadJsonObject[MOE_DATA][IS_USER_DELETION_SUCCESS]


### PR DESCRIPTION
### Description
- Getting typescript error on payload parser:
`Argument of type 'Object' is not assignable to parameter of type 'string'`

<img width="1256" alt="image" src="https://github.com/moengage/React-Native/assets/11868557/39cc5673-8d1d-4012-86f3-e39b70c66664">

