### PR TITLE
Add type MoEInAppClickData for better type inference

### DIFF
--- a/sdk/core/src/index.ts
+++ b/sdk/core/src/index.ts
@@ -59,6 +59,7 @@ import { MoEngageNudgePosition } from "../src/models/MoEngageNudgePosition";
 import MoEAnalyticsConfig from "../src/models/MoEAnalyticsConfig";
 import { MoESupportedAttributes } from "./models/MoESupportedAttributes";
 import * as MoECoreHandler from "./utils/MoECoreHandler";
+import MoEInAppClickData from "./models/MoEInAppClickData";
 
 const PLATFORM_IOS = "ios";
 const PLATFORM_ANDROID = "android";
@@ -137,7 +138,7 @@ type NotificationEventTypeMap = {
   "pushTokenGenerated": MoEPushToken,
   "pushClicked": MoEPushPayload,
   "inAppCampaignShown": MoEInAppData,
-  "inAppCampaignClicked": MoEInAppData,
+  "inAppCampaignClicked": MoEInAppClickData,
   "inAppCampaignDismissed": MoEInAppData,
   "inAppCampaignCustomAction": MoEInAppData,
   "inAppCampaignSelfHandled": MoESelfHandledCampaignData
@@ -755,6 +756,7 @@ var ReactMoE = {
 export {
   MoEInAppCustomAction,
   MoEInAppNavigation,
+  MoEInAppClickData,
   MoESelfHandledCampaignData,
   MoEGeoLocation,
   MoEProperties,

--- a/sdk/core/src/models/MoEInAppClickData.ts
+++ b/sdk/core/src/models/MoEInAppClickData.ts
@@ -1,0 +1,19 @@
+import MoEAccountMeta from "./MoEAccountMeta";
+import MoECampaignData from "./MoECampaignData";
+import MoEInAppNavigation from "./MoEInAppNavigation";
+import { MoEPlatform } from "./MoEPlatform";
+
+export default class MoEInAppClickData {
+    accountMeta: MoEAccountMeta;
+    platform: MoEPlatform;
+    campaignData: MoECampaignData;
+    action: MoEInAppNavigation;
+
+    constructor(accountMeta: MoEAccountMeta, platform: MoEPlatform, campaignData: MoECampaignData, action: MoEInAppNavigation) {
+        this.accountMeta = accountMeta;
+        this.platform = platform;
+        this.campaignData = campaignData;
+        this.action = action;
+    }
+
+}

--- a/sdk/core/src/moeParser/MoEInAppParser.ts
+++ b/sdk/core/src/moeParser/MoEInAppParser.ts
@@ -2,6 +2,7 @@ import MoEngageLogger from "../logger/MoEngageLogger";
 import MoECampaignContext from "../models/MoECampaignContext";
 import MoECampaignData from "../models/MoECampaignData";
 import MoEClickData from "../models/MoEClickData";
+import MoEInAppClickData from "../models/MoEInAppClickData";
 import MoEInAppCustomAction from "../models/MoEInAppCustomAction";
 import MoEInAppData from "../models/MoEInAppData";
 import MoEInAppNavigation from "../models/MoEInAppNavigation";
@@ -222,7 +223,7 @@ export function getNavigationObj(json: { [k: string]: any }, accountMetaPayload:
         var platform = json[MOE_PLATFORM];
         var accountMeta = getMoEAccountMeta(accountMetaPayload);
         var action = getMoEInAppNavigation(json);
-        return new MoEClickData(accountMeta, platform, campaignData, action);
+        return new MoEInAppClickData(accountMeta, platform, campaignData, action);
     }
     else return undefined
 }


### PR DESCRIPTION
### Jira Ticket
N/A

### Description
This commit adds a better type for type inference when using
`ReactMoE.setEventListener('inAppCampaignClicked', ...)`

Please note, the type for
`ReactMoE.setEventListener('inAppCampaignCustomAction', ...)`
might need updating as well