### PR TITLE
Replace const enum with enum in MoEngageLogLevel for compatibility

### DIFF
--- a/sdk/core/src/models/MoEngageLogLevel.ts
+++ b/sdk/core/src/models/MoEngageLogLevel.ts
@@ -1,7 +1,7 @@
 /**
  * Different Log Level Supported by the {@link MoEngageLogConfig}
  */
-const enum MoEngageLogLevel {
+enum MoEngageLogLevel {
 
     /**
      * No logs from the SDK would be printed.


### PR DESCRIPTION
Changed MoEngageLogLevel from const enum to enum in sdk/core/src/models/MoEngageLogLevel.ts. This improves compatibility for consumers of the SDK by avoiding issues with TypeScript compilation and toolchain support.

### Jira Ticket
N/A

### Description
Description: This PR changes the definition of MoEngageLogLevel in sdk/core/src/models/MoEngageLogLevel.ts from const enum to enum.
Reason:
Using const enum can cause compatibility issues in SDKs or libraries consumed by external TypeScript or JavaScript projects, as it requires specific TypeScript compilation settings and isn’t supported by all toolchains. Switching to a regular enum ensures broader compatibility for all consumers.
![image](https://github.com/user-attachments/assets/e03f5c3b-a7a0-4b06-ad8d-6a3df33805bc)


Changes:
Replaced const enum MoEngageLogLevel with enum MoEngageLogLevel.
No functional changes; this is a compatibility and interoperability improvement.
