### PR TITLE
fix(expo-plugin): move android_initialisation_config.xml to res/xml/

### DIFF
--- a/sdk/expo/src/android/constants.ts
+++ b/sdk/expo/src/android/constants.ts
@@ -45,7 +45,11 @@ export const moEngageExpoNotificationServiceEntry = {
 };
 
 export const drawableResourcePath = './android/app/src/main/res/drawable';
-export const xmlValuesResourcePath = './android/app/src/main/res/values';
+// android_initialisation_config.xml uses <MoEngageConfiguration> as its root
+// element, which is not a valid Android resource type. Files in res/values/
+// must use <resources> as their root. The correct directory is res/xml/, which
+// accepts arbitrary XML and is not processed by the resource merger.
+export const xmlValuesResourcePath = './android/app/src/main/res/xml';
 
 export const googleFirebaseMessagingGroup = 'com.google.firebase';
 export const googleFirebaseMessagingModule = 'firebase-messaging';


### PR DESCRIPTION
## Summary                                                                                                                 
                                                                                                                             
  The Expo config plugin incorrectly copies `android_initialisation_config.xml`                                              
  into `android/app/src/main/res/values/`. This causes a hard build failure during
  the `packageDebugResources` / `packageReleaseResources` Gradle task for all users                                          
  of the Expo managed workflow.                                                                                              

  **Error produced:**

  ERROR: .../res/values/android_initialisation_config.xml:
    Resource and asset merger: Can't determine type for tag
    'YOUR_APP_ID'

  **Affected file:**
  `src/android/constants.ts` (line 48) → compiled to `build/android/constants.js` (line 44)

  ---

  ## Root Cause

  The Android resource merger enforces strict rules on the contents of `res/values/`.
  Every XML file placed there **must** have `<resources>` as its root element, and
  every child element must be a recognised Android resource type (`<string>`,
  `<color>`, `<dimen>`, etc.).

  `android_initialisation_config.xml` uses `<MoEngageConfiguration>` as its root,
  which the resource merger cannot type-check — hence the `Can't determine type for
  tag` error.

  **From the official Android documentation on
  [`res/values/`](https://developer.android.com/guide/topics/resources/providing-resources#table1):**

  > XML files containing simple values, such as strings, integers, and colors.
  > Whereas other `res/` subdirectories define a single resource per file, files
  > in `res/values/` describe multiple resources. The root element of these files
  > **must** be a `<resources>` element.

  The correct directory is `res/xml/`, which is explicitly designed for
  arbitrary XML files read at runtime:

  **From the official Android documentation on
  [`res/xml/`](https://developer.android.com/guide/topics/resources/more-resources#Xml):**

  > Arbitrary XML files that can be read at runtime by calling
  > `Resources.getXML()`. Various XML configuration files must be saved here.

  The MoEngage Android SDK reads `android_initialisation_config.xml` via its own
  XML parser — not through Android's `<resources>` system — making `res/xml/` the
  semantically and technically correct location.

  ---

  ## Change

  **`src/android/constants.ts`:**

  ```diff
  -export const xmlValuesResourcePath = './android/app/src/main/res/values';
  +export const xmlValuesResourcePath = './android/app/src/main/res/xml';
  ```

  The res/xml/ directory is already present in Expo-managed Android projects
  (Expo itself places locales_config.xml there), so no directory creation is
  needed.

  ---
  Steps to Reproduce

  1. Create a new Expo managed project with react-native-expo-moengage configured
  in app.json plugins.
  2. Run npx expo prebuild --platform android.
  3. Run npx expo run:android or ./gradlew app:assembleDebug.

  Result: Build fails with:
  Task :app:packageDebugResources FAILED
  ERROR: .../res/values/android_initialisation_config.xml:
    Resource and asset merger: Can't determine type for tag '<appId>YOUR_APP_ID</appId>'

  Expected: Build succeeds; android_initialisation_config.xml is placed in
  res/xml/ where the resource merger does not attempt to type-check its elements.

  ---
  Testing

  After applying this patch:

  1. Run npx expo prebuild --platform android --clean.
  2. Verify android/app/src/main/res/xml/android_initialisation_config.xml exists.
  3. Verify android/app/src/main/res/values/android_initialisation_config.xml does not exist.
  4. Run npx expo run:android — build should succeed.
  5. Confirm MoEngage push notifications and analytics initialise correctly at runtime.

  ---
  References

  - Android resource types — res/values/ requirements:
  https://developer.android.com/guide/topics/resources/providing-resources#table1
  - Android res/xml/ for arbitrary XML: https://developer.android.com/guide/topics/resources/more-resources#Xml
  - Android resource type overview: https://developer.android.com/guide/topics/resources/available-resources
  - Resources.getXML() API: https://developer.android.com/reference/android/content/res/Resources#getXml(int)