### PR TITLE
MOEN-44435: Automate iOS dependency updates

### DIFF
--- a/.github/scripts/update-ios-deps.main.kts
+++ b/.github/scripts/update-ios-deps.main.kts
@@ -1,0 +1,192 @@
+#!/usr/bin/env kotlin
+
+@file:DependsOn("org.json:json:20251224")
+
+import java.io.File
+import java.util.Base64
+import org.json.JSONObject
+
+// ── Configuration ──────────────────────────────────────────────────────────────
+
+val MOENGAGE_OWNER = "moengage"
+val PLUGINBASE_REPO = "iOS-PluginBase"
+
+data class PodConfig(
+    val podName: String,
+    val pluginRepo: String,
+    val podspecPath: String,
+    val changelogPath: String
+)
+
+val podConfigs = listOf(
+    PodConfig("MoEngagePluginBase",        "iOS-PluginBase",           "sdk/core/ReactNativeMoEngage.podspec",                   "sdk/core/CHANGELOG.md"),
+    PodConfig("MoEngagePluginInbox",       "apple-plugin-inbox",       "sdk/inbox/ReactNativeMoEngageInbox.podspec",             "sdk/inbox/CHANGELOG.md"),
+    PodConfig("MoEngagePluginCards",       "apple-plugin-cards",       "sdk/cards/ReactNativeMoEngageCards.podspec",             "sdk/cards/CHANGELOG.md"),
+    PodConfig("MoEngagePluginGeofence",    "apple-plugin-geofence",    "sdk/geofence/ReactNativeMoEngageGeofence.podspec",       "sdk/geofence/CHANGELOG.md"),
+    PodConfig("MoEngagePluginPersonalize", "apple-plugin-personalize", "sdk/personalize/ReactNativeMoEngagePersonalize.podspec", "sdk/personalize/CHANGELOG.md")
+)
+
+// ── GitHub API: fetch upstream package.json ────────────────────────────────────
+
+fun fetchUpstreamPackageJson(repo: String): JSONObject {
+    val process = ProcessBuilder(
+        "gh", "api",
+        "-H", "Accept: application/vnd.github+json",
+        "repos/$MOENGAGE_OWNER/$repo/contents/package.json"
+    ).redirectErrorStream(true).start()
+    val output = process.inputStream.bufferedReader().readText()
+    val exit = process.waitFor()
+    if (exit != 0) error("gh api failed for $repo: $output")
+    val response = JSONObject(output)
+    val encoded = response.getString("content").replace("\n", "").replace(" ", "")
+    val decoded = String(Base64.getDecoder().decode(encoded))
+    return JSONObject(decoded)
+}
+
+fun fetchLatestPodVersion(repo: String): String {
+    val pkg = fetchUpstreamPackageJson(repo)
+    return pkg.getJSONArray("packages").getJSONObject(0).getString("version")
+}
+
+fun fetchPluginBaseSdkVerMin(): String? {
+    return try {
+        fetchUpstreamPackageJson(PLUGINBASE_REPO).optString("sdkVerMin").ifEmpty { null }
+    } catch (e: Exception) {
+        println("  WARN: failed to read sdkVerMin from $PLUGINBASE_REPO: ${e.message}")
+        null
+    }
+}
+
+// ── Podspec edits ──────────────────────────────────────────────────────────────
+
+fun podDependencyRegex(podName: String): Regex {
+    // Matches: s.dependency '<podName>','X.Y.Z'  OR  "...",'...'  OR  '...', "..."  etc.
+    val name = Regex.escape(podName)
+    return Regex("""s\.dependency\s+["']$name["']\s*,\s*["']([^"']+)["']""")
+}
+
+fun readCurrentPodVersion(file: File, podName: String): String? {
+    val match = podDependencyRegex(podName).find(file.readText()) ?: return null
+    return match.groupValues[1]
+}
+
+fun updatePodspecVersion(file: File, podName: String, oldVersion: String, newVersion: String) {
+    val content = file.readText()
+    val regex = podDependencyRegex(podName)
+    val match = regex.find(content) ?: error("Pod dependency line not found for $podName in ${file.path}")
+    val oldLine = match.value
+    val newLine = oldLine.replace("\"$oldVersion\"", "\"$newVersion\"").replace("'$oldVersion'", "'$newVersion'")
+    file.writeText(content.replace(oldLine, newLine))
+}
+
+// ── Changelog edits (translated from update-bom.main.kts) ──────────────────────
+
+fun appendIosChangelogEntries(file: File, lines: List<String>) {
+    if (lines.isEmpty()) return
+    val fileLines = file.readLines().toMutableList()
+    val iosSectionRegex = Regex("""^- iOS$""")
+    val datedEntryRegex = Regex("""^# \d{2}-\d{2}-\d{4}$""")
+
+    val firstDatedEntry = fileLines.indexOfFirst { datedEntryRegex.matches(it) }
+
+    // If the file starts with a dated entry, there is no unreleased section. Prepend one
+    // so we never pollute a released entry.
+    if (firstDatedEntry == 0) {
+        val unreleased = mutableListOf("# Release Date", "", "## Release Version", "", "- iOS")
+        unreleased.addAll(lines)
+        unreleased.add("")
+        fileLines.addAll(0, unreleased)
+        file.writeText(fileLines.joinToString("\n") + "\n")
+        return
+    }
+
+    val searchEnd = if (firstDatedEntry > 0) firstDatedEntry else fileLines.size
+    val iosIndex = fileLines.subList(0, searchEnd).indexOfFirst { iosSectionRegex.matches(it) }
+    val insertAt: Int
+    if (iosIndex >= 0) {
+        // Insert after the iOS heading (and any existing iOS sub-bullets, before next top-level heading)
+        var cursor = iosIndex + 1
+        while (cursor < searchEnd && fileLines[cursor].startsWith("  ")) cursor++
+        insertAt = cursor
+    } else {
+        val tail = if (firstDatedEntry > 0) firstDatedEntry else fileLines.size
+        fileLines.add(tail, "- iOS")
+        insertAt = tail + 1
+    }
+    fileLines.addAll(insertAt, lines)
+    file.writeText(fileLines.joinToString("\n") + "\n")
+}
+
+// ── Main ───────────────────────────────────────────────────────────────────────
+
+fun updateIos() {
+    if (System.getenv("GH_TOKEN").isNullOrEmpty() && System.getenv("GITHUB_TOKEN").isNullOrEmpty()) {
+        error("GH_TOKEN (or GITHUB_TOKEN) env var required to call gh api")
+    }
+    val projectRoot = File(".").canonicalFile
+    println("Project root: $projectRoot")
+    println()
+    println("Fetching latest plugin versions from upstream package.json files...")
+
+    data class ResolvedUpdate(val config: PodConfig, val oldVersion: String, val newVersion: String)
+    val updates = mutableListOf<ResolvedUpdate>()
+    var pluginBaseBumped = false
+
+    for (config in podConfigs) {
+        val podspec = File(projectRoot, config.podspecPath)
+        if (!podspec.exists()) {
+            println("  WARN: ${config.podspecPath} not found, skipping.")
+            continue
+        }
+        val current = readCurrentPodVersion(podspec, config.podName)
+        if (current == null) {
+            println("  WARN: could not find ${config.podName} dependency in ${config.podspecPath}; skipping.")
+            continue
+        }
+
+        val latest = try {
+            fetchLatestPodVersion(config.pluginRepo)
+        } catch (e: Exception) {
+            println("  WARN: could not fetch latest for ${config.podName} from ${config.pluginRepo}: ${e.message}")
+            continue
+        }
+
+        if (current == latest) {
+            println("  SKIP: ${config.podName} already at $current")
+        } else {
+            println("  BUMP: ${config.podName} $current -> $latest")
+            updates.add(ResolvedUpdate(config, current, latest))
+            updatePodspecVersion(podspec, config.podName, current, latest)
+            if (config.podName == "MoEngagePluginBase") pluginBaseBumped = true
+        }
+    }
+
+    if (updates.isEmpty()) {
+        println()
+        println("No updates to apply.")
+        return
+    }
+
+    println()
+    println("Updating CHANGELOGs...")
+    val sdkVerMin = if (pluginBaseBumped) fetchPluginBaseSdkVerMin() else null
+    for (u in updates) {
+        val changelog = File(projectRoot, u.config.changelogPath)
+        if (!changelog.exists()) {
+            println("  WARN: ${u.config.changelogPath} not found, skipping changelog update.")
+            continue
+        }
+        val lines = mutableListOf<String>()
+        lines.add("  - [minor] updating `${u.config.podName}` to `${u.newVersion}`")
+        if (u.config.podName == "MoEngagePluginBase" && sdkVerMin != null) {
+            lines.add("  - [minor] updating `MoEngage-iOS-SDK` to `$sdkVerMin`")
+        }
+        appendIosChangelogEntries(changelog, lines)
+        println("  UPDATED: ${u.config.changelogPath}")
+    }
+
+    println()
+    println("Done. ${updates.size} pod(s) bumped.")
+}
+
+updateIos()

--- a/.github/workflows/update_dependency.yml
+++ b/.github/workflows/update_dependency.yml
@@ -7,6 +7,15 @@ on:
         type: string
         description: 'Ticket number (e.g. MOEN-12345)'
         required: true
+      target:
+        type: choice
+        description: 'Which platform(s) to update'
+        required: true
+        default: both
+        options:
+          - android
+          - ios
+          - both
 
 jobs:
   update-dependency:
@@ -17,9 +26,21 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.SDK_BOT_ACCESS_TOKEN }}
-      - name: Update dependency versions
-        run: |
-          kotlin .github/scripts/update-bom.main.kts
+
+      - name: Update Android dependencies
+        id: android
+        if: inputs.target == 'android' || inputs.target == 'both'
+        continue-on-error: true
+        run: kotlin .github/scripts/update-bom.main.kts
+
+      - name: Update iOS dependencies
+        id: ios
+        if: inputs.target == 'ios' || inputs.target == 'both'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.SDK_BOT_ACCESS_TOKEN }}
+        run: kotlin .github/scripts/update-ios-deps.main.kts
+
       - name: Check for changes
         id: changes
         run: |
@@ -31,27 +52,45 @@ jobs:
             echo "Files updated:"
             git diff --name-only
           fi
+
       - name: Create Pull Request
         if: steps.changes.outputs.changed == 'true'
         env:
           GH_TOKEN: ${{ secrets.SDK_BOT_ACCESS_TOKEN }}
+          TICKET: ${{ github.event.inputs.ticketNumber }}
+          TARGET: ${{ github.event.inputs.target }}
+          ANDROID_OUTCOME: ${{ steps.android.outcome }}
+          IOS_OUTCOME: ${{ steps.ios.outcome }}
         run: |
           git config user.name "sdk-bot-user"
           git config user.email "sdk.bot@moengage.com"
           DATE=$(date +%Y-%m-%d)
-          TICKET="${{ github.event.inputs.ticketNumber }}"
           BRANCH="${TICKET}/dependency_update"
-          echo $BRANCH
+
+          case "$TARGET" in
+            android) SCOPE_LABEL="Android Dependency Update" ;;
+            ios)     SCOPE_LABEL="iOS Dependency Update" ;;
+            *)       SCOPE_LABEL="Dependency Update" ;;
+          esac
+
+          # Build PR body
+          PLATFORM_STATUS=""
+          if [ "$TARGET" = "android" ] || [ "$TARGET" = "both" ]; then
+            PLATFORM_STATUS+="- Android: ${ANDROID_OUTCOME:-skipped}\n"
+          fi
+          if [ "$TARGET" = "ios" ] || [ "$TARGET" = "both" ]; then
+            PLATFORM_STATUS+="- iOS: ${IOS_OUTCOME:-skipped}\n"
+          fi
+
           git checkout -b "$BRANCH"
           git add -A
-          git commit -m "${TICKET}: Dependency Update ${DATE}"
+          git commit -m "${TICKET}: ${SCOPE_LABEL} ${DATE}"
           git push -u origin "$BRANCH"
+
+          BODY=$(printf "## Summary\nAutomated dependency update (target: \`%s\`).\n\n## Platform status\n%b" \
+            "$TARGET" "$PLATFORM_STATUS")
+
           gh pr create \
             --base development \
-            --title "${TICKET}: Dependency Update ${DATE}" \
-            --body "$(cat <<'EOF'
-          ## Summary
-          Updated android-bom and plugin-base-bom to the latest versions from Maven Central.
-          Only modules with changed artifacts were updated.
-          EOF
-          )"
+            --title "${TICKET}: ${SCOPE_LABEL} ${DATE}" \
+            --body "$BODY"


### PR DESCRIPTION
### Jira Ticket
https://moengagetrial.atlassian.net/browse/MOEN-44435
### Description
Adds iOS dependency-update automation to mirror Android's existing automation, and unifies both behind a single workflow with a platform dropdown.

## What changed

**New** — [`.github/scripts/update-ios-deps.main.kts`](.github/scripts/update-ios-deps.main.kts)
- Fetches latest pod versions from `iOS-PluginBase`, `apple-plugin-inbox/cards/geofence/personalize` upstream `package.json` files via `gh api`
- Rewrites `s.dependency 'MoEngagePlugin*', 'X.Y.Z'` lines in the 5 podspecs (handles all 3 quote/whitespace styles in use)
- Appends CHANGELOG entries under `- iOS` heading; **creates an unreleased section** if the CHANGELOG starts with a dated entry (avoids polluting released versions)
- When `MoEngagePluginBase` is bumped, also adds the corresponding `MoEngage-iOS-SDK` line to `sdk/core/CHANGELOG.md` (read from PluginBase's `sdkVerMin`)

**Modified** — [`.github/workflows/update_dependency.yml`](.github/workflows/update_dependency.yml)
- New `target` input: `choice` of `android | ios | both` (default `both`)
- Conditional Android + iOS steps with `continue-on-error: true` for partial-failure isolation
- Scope-aware PR title: `<TICKET>: <Android|iOS|>Dependency Update <DATE>`
- PR body lists per-platform step outcomes

**Unchanged** — [`.github/scripts/update-bom.main.kts`](.github/scripts/update-bom.main.kts)
- Android script preserves its existing behavior

## Behavior
- **No semver filter** — auto-bumps any forward version diff (patch/minor/major), matching the existing Android script's behavior
- **Sequential execution** in a single job — simpler git/PR coordination than parallel
- **Runner**: `ubuntu-latest` (no macOS needed — `gh api` + `kotlin` only)
- **Source of truth** for iOS: upstream plugin repos' `package.json` — same manifest used by [`iOS-PluginBase/Utilities/release_dependents.rb`](https://github.com/moengage/iOS-PluginBase/blob/development/Utilities/release_dependents.rb)
- **Trunk-drift safety**: no `pod trunk info` sanity check in the script — covered by [`pull_request_verification.yml`](.github/workflows/pull_request_verification.yml) which runs `pod install` on every PR

## Usage
1. Actions → **Update Dependency** → Run workflow
2. Enter ticket number (e.g. `MOEN-12345`)
3. Pick `target`: `android` / `ios` / `both`
4. Workflow opens a PR against `development` with scope-appropriate title

## Dry-run validation (31 scenarios run locally)

- No-op idempotence (script + workflow change-detection)
- Patch / minor / major version downgrade → re-bump
- All 5 pods bumped in one run
- Missing `GH_TOKEN` → fail-fast with clear error
- Malformed podspec (missing dep line) → WARN, other pods proceed
- Byte-exact format preservation across single-quote / double-quote / mixed-quote / space-after-comma styles
- Combined `target=both` execution — both platforms in one PR diff, no file conflicts
- PR title/body assembly for each target value, including partial-failure case
- CHANGELOG: existing `- iOS` heading reused, no duplication
- CHANGELOG: sequential bumps on different modules don't create stray sections
- `gh api` response handling (base64 content arrives with newlines every 60 chars — script strips correctly)
- Upstream `package.json` versions verified against CocoaPods trunk for all 5 pods today — all match