### PR TITLE
MOEN-46303: Robust CHANGELOG anchoring + PR body improvements for dependency-update automation

### DIFF
--- a/.github/scripts/update-bom.main.kts
+++ b/.github/scripts/update-bom.main.kts
@@ -22,6 +22,7 @@ val MOENGAGE_GROUP = "com.moengage"
 
 val ANDROID_BOM_VERSION_KEY = "moengageNativeBOMVersion"
 val PLUGIN_BASE_BOM_VERSION_KEY = "moengagePluginBaseBOMVersion"
+val BUMP_SUMMARY_FILE = ".github/scripts/.bump-summary.txt"
 
 data class ModuleConfig(
     val gradleFilePath: String,
@@ -164,33 +165,52 @@ fun updateVersionInFile(file: File, versionKey: String, oldVersion: String, newV
 
 // ── Changelog Update ────────────────────────────────────────────────────────────
 
+// Anchor on the explicit "# Release Date" unreleased marker. Never scans past the first
+// "# ..." heading — released content is never touched.
+
+val RELEASE_DATE_MARKER = "# Release Date"
+
 fun updateChangelog(file: File, newAndroidBomVersion: String) {
-    val lines = file.readLines().toMutableList()
-    val bomLineRegex = Regex("""^\s+-\s+\[minor]\s+updating\s+`android-bom`\s+to\s+`[^`]+`""")
-    val androidSectionRegex = Regex("""^- Android$""")
+    val fileLines = file.readLines().toMutableList()
     val newBomLine = "  - [minor] updating `android-bom` to `$newAndroidBomVersion`"
+    val bomLineRegex = Regex("""^\s+-\s+\[minor]\s+updating\s+`android-bom`\s+to\s+`[^`]+`""")
 
-    // Look for existing android-bom line in the unreleased section (before the first dated entry)
-    val firstDatedEntry = lines.indexOfFirst { it.matches(Regex("""^# \d{2}-\d{2}-\d{4}$""")) }
-    val searchEnd = if (firstDatedEntry > 0) firstDatedEntry else lines.size
+    val hasUnreleasedSection = fileLines.isNotEmpty() && fileLines[0].trim() == RELEASE_DATE_MARKER
 
-    val existingBomLineIndex = lines.subList(0, searchEnd).indexOfFirst { bomLineRegex.matches(it) }
-    if (existingBomLineIndex >= 0) {
-        lines[existingBomLineIndex] = newBomLine
-    } else {
-        // Find the "- Android" section in the unreleased block and add the line after it
-        val androidIndex = lines.subList(0, searchEnd).indexOfFirst { androidSectionRegex.matches(it) }
-        if (androidIndex >= 0) {
-            lines.add(androidIndex + 1, newBomLine)
-        } else {
-            // No Android section exists, add one before the first dated entry or at end of unreleased block
-            val insertAt = if (firstDatedEntry > 0) firstDatedEntry else lines.size
-            lines.add(insertAt, "- Android")
-            lines.add(insertAt + 1, newBomLine)
-        }
+    if (!hasUnreleasedSection) {
+        // No unreleased section — prepend one with the "- Android" heading and the bom bullet.
+        val prefix = mutableListOf("# Release Date", "", "## Release Version", "", "- Android", newBomLine, "")
+        fileLines.addAll(0, prefix)
+        file.writeText(fileLines.joinToString("\n") + "\n")
+        return
     }
 
-    file.writeText(lines.joinToString("\n") + "\n")
+    // Unreleased section exists. Its end is the next "# ..." heading (any format).
+    val unreleasedEnd = (1 until fileLines.size)
+        .firstOrNull { fileLines[it].startsWith("# ") }
+        ?: fileLines.size
+
+    // If an android-bom bullet already exists in the unreleased section, update it in place.
+    val existingBomLineIndex = fileLines.subList(0, unreleasedEnd).indexOfFirst { bomLineRegex.matches(it) }
+    if (existingBomLineIndex >= 0) {
+        fileLines[existingBomLineIndex] = newBomLine
+        file.writeText(fileLines.joinToString("\n") + "\n")
+        return
+    }
+
+    // Find or create the "- Android" heading within the unreleased section.
+    val androidIndex = fileLines.subList(0, unreleasedEnd).indexOfFirst { it == "- Android" }
+    if (androidIndex >= 0) {
+        // Insert after existing "- Android" sub-bullets.
+        var cursor = androidIndex + 1
+        while (cursor < unreleasedEnd && fileLines[cursor].startsWith("  ")) cursor++
+        fileLines.add(cursor, newBomLine)
+    } else {
+        fileLines.add(unreleasedEnd, "- Android")
+        fileLines.add(unreleasedEnd + 1, newBomLine)
+    }
+
+    file.writeText(fileLines.joinToString("\n") + "\n")
 }
 
 // ── Main ───────────────────────────────────────────────────────────────────────
@@ -237,6 +257,15 @@ fun updateBom() {
 
     println()
     println("Updating modules...")
+
+    val summaryFile = File(projectRoot, BUMP_SUMMARY_FILE)
+    summaryFile.parentFile?.mkdirs()
+    if (currentAndroidBomVersion != newAndroidBomVersion && androidBomChanged.isNotEmpty()) {
+        summaryFile.appendText("- Android: `android-bom` $currentAndroidBomVersion → $newAndroidBomVersion\n")
+    }
+    if (currentPluginBaseBomVersion != newPluginBaseBomVersion && pluginBaseBomChanged.isNotEmpty()) {
+        summaryFile.appendText("- Android: `plugin-base-bom` $currentPluginBaseBomVersion → $newPluginBaseBomVersion\n")
+    }
 
     for (config in moduleConfigs) {
         val file = File(projectRoot, config.gradleFilePath)

--- a/.github/scripts/update-ios-deps.main.kts
+++ b/.github/scripts/update-ios-deps.main.kts
@@ -10,6 +10,7 @@ import org.json.JSONObject
 
 val MOENGAGE_OWNER = "moengage"
 val PLUGINBASE_REPO = "iOS-PluginBase"
+val BUMP_SUMMARY_FILE = ".github/scripts/.bump-summary.txt"
 
 data class PodConfig(
     val podName: String,
@@ -79,41 +80,84 @@ fun updatePodspecVersion(file: File, podName: String, oldVersion: String, newVer
     file.writeText(content.replace(oldLine, newLine))
 }
 
-// ── Changelog edits (translated from update-bom.main.kts) ──────────────────────
+// ── Changelog edits ────────────────────────────────────────────────────────────
 
-fun appendIosChangelogEntries(file: File, lines: List<String>) {
-    if (lines.isEmpty()) return
+// Anchor on the explicit "# Release Date" unreleased marker (the convention already in use).
+// This avoids trying to detect where released content STARTS via regex — that approach was
+// fragile against trailing whitespace on dated headings and other formatting quirks.
+
+val RELEASE_DATE_MARKER = "# Release Date"
+
+// Extract artifact name (e.g. "MoEngagePluginBase") from a bullet like
+//   "  - [minor] updating `MoEngagePluginBase` to `6.10.0`"
+// so a subsequent run can UPDATE the existing bullet rather than duplicating it.
+val ARTIFACT_LINE_REGEX = Regex("""updating\s+`([^`]+)`\s+to\s+`[^`]+`""")
+
+fun artifactMatcher(bullet: String): Regex? {
+    val m = ARTIFACT_LINE_REGEX.find(bullet) ?: return null
+    val artifact = Regex.escape(m.groupValues[1])
+    return Regex("""updating\s+`$artifact`\s+to\s+`[^`]+`""")
+}
+
+fun appendIosChangelogEntries(file: File, bullets: List<String>) {
+    if (bullets.isEmpty()) return
     val fileLines = file.readLines().toMutableList()
-    val iosSectionRegex = Regex("""^- iOS$""")
-    val datedEntryRegex = Regex("""^# \d{2}-\d{2}-\d{4}$""")
 
-    val firstDatedEntry = fileLines.indexOfFirst { datedEntryRegex.matches(it) }
+    val hasUnreleasedSection = fileLines.isNotEmpty() && fileLines[0].trim() == RELEASE_DATE_MARKER
 
-    // If the file starts with a dated entry, there is no unreleased section. Prepend one
-    // so we never pollute a released entry.
-    if (firstDatedEntry == 0) {
-        val unreleased = mutableListOf("# Release Date", "", "## Release Version", "", "- iOS")
-        unreleased.addAll(lines)
-        unreleased.add("")
-        fileLines.addAll(0, unreleased)
+    if (!hasUnreleasedSection) {
+        // No unreleased section — prepend a fresh one with the platform heading and bullets.
+        val prefix = mutableListOf("# Release Date", "", "## Release Version", "", "- iOS")
+        prefix.addAll(bullets)
+        prefix.add("")
+        fileLines.addAll(0, prefix)
         file.writeText(fileLines.joinToString("\n") + "\n")
         return
     }
 
-    val searchEnd = if (firstDatedEntry > 0) firstDatedEntry else fileLines.size
-    val iosIndex = fileLines.subList(0, searchEnd).indexOfFirst { iosSectionRegex.matches(it) }
+    // Unreleased section exists. Its end is the next top-level "# ..." heading — whatever
+    // format it uses (dated, annotated, trailing whitespace — irrelevant). We never
+    // touch anything past this boundary.
+    val unreleasedEnd = (1 until fileLines.size)
+        .firstOrNull { fileLines[it].startsWith("# ") }
+        ?: fileLines.size
+
+    // For each new bullet: if an existing bullet for the same artifact is present in the
+    // unreleased section, REPLACE it (so re-runs update in place instead of duplicating).
+    // Otherwise queue it for insertion under the "- iOS" heading.
+    val remaining = mutableListOf<String>()
+    for (bullet in bullets) {
+        val matcher = artifactMatcher(bullet)
+        var replaced = false
+        if (matcher != null) {
+            for (i in 0 until unreleasedEnd) {
+                if (matcher.containsMatchIn(fileLines[i])) {
+                    fileLines[i] = bullet
+                    replaced = true
+                    break
+                }
+            }
+        }
+        if (!replaced) remaining.add(bullet)
+    }
+    if (remaining.isEmpty()) {
+        file.writeText(fileLines.joinToString("\n") + "\n")
+        return
+    }
+
+    // Find or create the "- iOS" heading inside the unreleased section, then insert
+    // after its existing sub-bullets.
+    val iosIndex = fileLines.subList(0, unreleasedEnd).indexOfFirst { it == "- iOS" }
     val insertAt: Int
     if (iosIndex >= 0) {
-        // Insert after the iOS heading (and any existing iOS sub-bullets, before next top-level heading)
         var cursor = iosIndex + 1
-        while (cursor < searchEnd && fileLines[cursor].startsWith("  ")) cursor++
+        while (cursor < unreleasedEnd && fileLines[cursor].startsWith("  ")) cursor++
         insertAt = cursor
     } else {
-        val tail = if (firstDatedEntry > 0) firstDatedEntry else fileLines.size
-        fileLines.add(tail, "- iOS")
-        insertAt = tail + 1
+        fileLines.add(unreleasedEnd, "- iOS")
+        insertAt = unreleasedEnd + 1
     }
-    fileLines.addAll(insertAt, lines)
+    fileLines.addAll(insertAt, remaining)
     file.writeText(fileLines.joinToString("\n") + "\n")
 }
 
@@ -170,6 +214,8 @@ fun updateIos() {
     println()
     println("Updating CHANGELOGs...")
     val sdkVerMin = if (pluginBaseBumped) fetchPluginBaseSdkVerMin() else null
+    val summaryFile = File(projectRoot, BUMP_SUMMARY_FILE)
+    summaryFile.parentFile?.mkdirs()
     for (u in updates) {
         val changelog = File(projectRoot, u.config.changelogPath)
         if (!changelog.exists()) {
@@ -183,6 +229,10 @@ fun updateIos() {
         }
         appendIosChangelogEntries(changelog, lines)
         println("  UPDATED: ${u.config.changelogPath}")
+        summaryFile.appendText("- iOS: `${u.config.podName}` ${u.oldVersion} → ${u.newVersion}\n")
+    }
+    if (pluginBaseBumped && sdkVerMin != null) {
+        summaryFile.appendText("- iOS: `MoEngage-iOS-SDK` → $sdkVerMin\n")
     }
 
     println()

--- a/.github/workflows/update_dependency.yml
+++ b/.github/workflows/update_dependency.yml
@@ -27,6 +27,23 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.SDK_BOT_ACCESS_TOKEN }}
 
+      - name: Verify ticket branch is fresh
+        env:
+          GH_TOKEN: ${{ secrets.SDK_BOT_ACCESS_TOKEN }}
+          TICKET: ${{ github.event.inputs.ticketNumber }}
+        run: |
+          BRANCH="patch/${TICKET}/dependency_update"
+          if gh api "repos/${{ github.repository }}/branches/${BRANCH}" >/dev/null 2>&1; then
+            echo "::error::Branch '${BRANCH}' already exists on the remote. Use a fresh ticket, or delete the existing branch first."
+            exit 1
+          fi
+          echo "Branch '${BRANCH}' is available."
+
+      - name: Reset bump-summary tracker
+        run: |
+          mkdir -p .github/scripts
+          : > .github/scripts/.bump-summary.txt
+
       - name: Update Android dependencies
         id: android
         if: inputs.target == 'android' || inputs.target == 'both'
@@ -44,13 +61,14 @@ jobs:
       - name: Check for changes
         id: changes
         run: |
-          if git diff --quiet; then
+          # The bump-summary tracker is informational only; exclude from diff check.
+          if git diff --quiet -- ':(exclude).github/scripts/.bump-summary.txt'; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
             echo "No files were updated."
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
             echo "Files updated:"
-            git diff --name-only
+            git diff --name-only -- ':(exclude).github/scripts/.bump-summary.txt'
           fi
 
       - name: Create Pull Request
@@ -65,7 +83,7 @@ jobs:
           git config user.name "sdk-bot-user"
           git config user.email "sdk.bot@moengage.com"
           DATE=$(date +%Y-%m-%d)
-          BRANCH="${TICKET}/dependency_update"
+          BRANCH="patch/${TICKET}/dependency_update"
 
           case "$TARGET" in
             android) SCOPE_LABEL="Android Dependency Update" ;;
@@ -73,7 +91,7 @@ jobs:
             *)       SCOPE_LABEL="Dependency Update" ;;
           esac
 
-          # Build PR body
+          # Per-platform outcome section
           PLATFORM_STATUS=""
           if [ "$TARGET" = "android" ] || [ "$TARGET" = "both" ]; then
             PLATFORM_STATUS+="- Android: ${ANDROID_OUTCOME:-skipped}\n"
@@ -82,13 +100,19 @@ jobs:
             PLATFORM_STATUS+="- iOS: ${IOS_OUTCOME:-skipped}\n"
           fi
 
+          # Bumps section (from the tracker file both scripts wrote to)
+          BUMPS_SECTION=""
+          if [ -s .github/scripts/.bump-summary.txt ]; then
+            BUMPS_SECTION="\n## Bumps\n$(cat .github/scripts/.bump-summary.txt)\n"
+          fi
+
           git checkout -b "$BRANCH"
-          git add -A
+          git add -A -- ':(exclude).github/scripts/.bump-summary.txt'
           git commit -m "${TICKET}: ${SCOPE_LABEL} ${DATE}"
           git push -u origin "$BRANCH"
 
-          BODY=$(printf "## Summary\nAutomated dependency update (target: \`%s\`).\n\n## Platform status\n%b" \
-            "$TARGET" "$PLATFORM_STATUS")
+          BODY=$(printf "## Summary\nAutomated dependency update (target: \`%s\`).\n\n## Platform status\n%b%b" \
+            "$TARGET" "$PLATFORM_STATUS" "$BUMPS_SECTION")
 
           gh pr create \
             --base development \


### PR DESCRIPTION
### Jira Ticket
[MOEN-46303](https://moengagetrial.atlassian.net/browse/MOEN-46303)

### Description

## Summary

Fixes root cause of the CHANGELOG-pollution bug that was patched manually in [PR #129](https://github.com/moengage/React-Native/pull/129), plus a few small improvements found during review.

## Motivation

[PR #128](https://github.com/moengage/React-Native/pull/128) (the first real production run of the automation) produced a diff that placed dependency bump entries **inside released sections** of several CHANGELOGs — for personalize on the iOS side, and for all 5 modules on the Android side. PR #129 manually moved those entries into unreleased sections, but the root causes in the scripts remained. This PR fixes those root causes.

## What changed

### 1. Robust CHANGELOG anchoring (bug fix)

The scripts previously tried to detect where released content starts via `Regex("^# \\d{2}-\\d{2}-\\d{4}$")`. That strict regex fails on trailing whitespace (the actual PR #128 trigger — the personalize CHANGELOG had `# 11-06-2026 ` with a trailing space) and any other date-format variation. When the regex fails, both scripts fall through and insert new entries into the most recent *released* section.

**Fix**: Anchor on the explicit `# Release Date` unreleased marker instead. If present, append into it; if absent, prepend a fresh unreleased section. Applied to both `update-ios-deps.main.kts` and `update-bom.main.kts`. The Android script never had the "prepend when missing" behavior at all — that's why PR #128 polluted every released Android section.

### 2. `patch/` branch prefix

Workflow-generated branches now follow the repo convention:
- Before: `${TICKET}/dependency_update`
- After: `patch/${TICKET}/dependency_update`

### 3. Pre-flight branch collision check

Before running the scripts, the workflow checks whether the target branch already exists on remote. If yes, it fails fast with a clear message: *"Branch already exists. Use a fresh ticket, or delete the existing branch first."* Enforces the "one ticket = one PR" invariant explicitly.

### 4. Duplicate-line protection

If a subsequent run bumps the same artifact to a newer version (e.g. `MoEngagePluginBase 6.10.0 → 6.10.1` after a previous run left `6.10.0` in the CHANGELOG), the existing bullet is updated in place instead of creating a duplicate.

### 5. Descriptive PR body

Both scripts now emit `.github/scripts/.bump-summary.txt` per-run. The workflow includes it in the PR body under a `## Bumps` section, so reviewers see the actual version changes without opening the diff.

## Files changed

- `.github/scripts/update-ios-deps.main.kts` — refactor `appendIosChangelogEntries`; artifact-level duplicate protection; emit bump summary
- `.github/scripts/update-bom.main.kts` — refactor `updateChangelog` with same anchoring pattern; prepend fresh unreleased section when missing; emit bump summary
- `.github/workflows/update_dependency.yml` — `patch/` prefix; pre-flight collision check; PR body enhancement

## Testing

**21 dry-run assertions across 7 scenarios pass locally** (kotlin 2.3.21, matching CI):

| # | Scenario | Assertions |
|---|---|---|
| A | Pathological PR #128 case — CHANGELOG starts with `# 11-06-2026 ` (trailing space) | Released 1.0.2 NOT polluted; fresh unreleased section prepended |
| B | CHANGELOG already has `# Release Date` unreleased section | Exactly one `# Release Date` marker; bump lands in unreleased |
| C | Re-run with same artifact | Bullet updated in place, no duplicate |
| D | `- Android` heading with pre-existing manual bullets | Manual bullets preserved; new bump appended |
| E | Byte-exact podspec format preservation across all 5 quote/whitespace styles | 5 podspecs byte-identical to HEAD after downgrade + bump |
| F | `.bump-summary.txt` emission | Correct format for iOS bumps + MoEngage-iOS-SDK line |
| G | Workflow YAML validity | Parses; has `patch/` prefix, pre-flight check, bumps section |

## Behavior when `# Release Date` section already exists

The refactored anchoring works as follows:

- **File starts with `# Release Date`** → append into the existing unreleased section. Finds or creates the `- iOS` / `- Android` heading within it; respects existing manual bullets; updates in place if the same artifact was bumped previously.
- **File starts with anything else** (dated heading, etc.) → prepend a fresh `# Release Date / ## Release Version / - <Platform>` section. Existing released content is never touched.

## Suggested smoke test before merge

Trigger the workflow on this PR branch (Actions → Update Dependency → Run workflow → select `patch/MOEN-46303/dep-automation-fix`) with a test ticket and `target=ios`. Expected: all pods SKIP (already latest), no diff, no PR created, workflow green. This validates the wiring in real CI without side-effects.

[MOEN-46303]: https://moengagetrial.atlassian.net/browse/MOEN-46303?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ